### PR TITLE
optional webhook url

### DIFF
--- a/replicate.js
+++ b/replicate.js
@@ -35,12 +35,12 @@ export class Replicate {
             event: "getPrediction",
         });
     }
-    async startPrediction(modelVersion, input) {
+    async startPrediction(modelVersion, input, webhookCompleted=null) {
         return await this.callHttpClient({
             url: "/predictions",
             method: "post",
             event: "startPrediction",
-            body: { version: modelVersion, input: input },
+            body: { version: modelVersion, input: input, webhook_completed: webhookCompleted },
         });
     }
     async callHttpClient({ url, method, event, body }) {

--- a/replicate.ts
+++ b/replicate.ts
@@ -60,12 +60,12 @@ export class Replicate {
     });
   }
 
-  async startPrediction(modelVersion: string, input: PredictionInput) {
+  async startPrediction(modelVersion: string, input: PredictionInput, webhookCompleted: string = null) {
     return await this.callHttpClient({
       url: "/predictions",
       method: "post",
       event: "startPrediction",
-      body: { version: modelVersion, input: input },
+      body: { version: modelVersion, input: input, webhook_completed: webhookCompleted },
     });
   }
 


### PR DESCRIPTION
## Description
Adds webhook support for `startPrediction`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #25 https://github.com/nicholascelestin/replicate-js/issues/25

## How to test
use a POST url for `webhookCompleted`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
