### PR TITLE
Fix Replicate is not a constructor

### DIFF
--- a/examples/browser.html
+++ b/examples/browser.html
@@ -3,7 +3,7 @@
     <body>
         <script type="module">
         // You can specify a specific version, branch, or sha: e.g. "https://cdn.jsdelivr.net/gh/nicholascelestin/replicate-js@0.0.6/replicate.js"
-        const Replicate = await import("https://cdn.jsdelivr.net/gh/nicholascelestin/replicate-js/replicate.js")
+        const {default: Replicate} = await import("https://cdn.jsdelivr.net/gh/nicholascelestin/replicate-js/replicate.js")
         console.log(Replicate)
     
         // set REPLICATE_API_TOKEN environment variable


### PR DESCRIPTION
When running just the html and proxy a "Replicate is not a constructor" error is thrown as it also contains some HTTP object. The constructor is under the "default" key. Which I extract here and rename "Replicate"

Not sure if this is the fix you want to go with or do something upstream.
