### PR TITLE
useful error if the requested model isn't found

### DIFF
--- a/replicate.ts
+++ b/replicate.ts
@@ -103,7 +103,9 @@ export class ReplicateModel {
 
   async getModelDetails() {
     const response = await this.replicate.getModel(this.path);
-    const modelVersions = response.results;
+    if (response.detail === "Not found.") {
+        throw new Error(`Model "${this.path}" not found`)
+    }    const modelVersions = response.results;
     const mostRecentVersion = modelVersions[0];
     const explicitlySelectedVersion = modelVersions.find(
       (m: { id: string }) => m.id == this.version


### PR DESCRIPTION
## Description
When model is not found (or undefined) this is the error:
```
file:///<path/to>/node_modules/replicate-js/replicate.js:77
        const mostRecentVersion = modelVersions[0];
```

This PR changes that to eg

```
file:///<path/to>/node_modules/replicate-js/replicate.js:70
            throw new Error(`Model "${this.path}" not found`)
                  ^

Error: Model "<username>/undefined" not found
```

## Related Issue(s)
Addresses #22

## How to test
Call `predict()` with a non-existent model

## Release Notes
```release-note
NONE
```

## Documentation
not required